### PR TITLE
02: Introduce dry-cli launcher and Aruba harness

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Ruby 4.0
       uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in dnsmadeeasy.gemspec
 gemspec
 
+gem 'aruba'
 gem 'rspec'
 gem 'rspec-its'
-gem 'aruba'
 gem 'rubocop'
 gem 'rubocop-rspec'

--- a/dnsmadeeasy.gemspec
+++ b/dnsmadeeasy.gemspec
@@ -69,9 +69,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'awesome_print'
   spec.add_dependency 'colored2'
+  spec.add_dependency 'dry-cli'
   spec.add_dependency 'hashie'
   spec.add_dependency 'sym'
   spec.add_dependency 'tsort'
+  spec.add_dependency 'tty-spinner'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'relaxed-rubocop'

--- a/docs/plan-zone-management.md
+++ b/docs/plan-zone-management.md
@@ -43,6 +43,24 @@ The zone-management specification lives in `docs/spec-zone-management.md`.
 5. Keep zone parsing isolated behind an adapter so `DNS::Zonefile::*` classes do not leak through the implementation.
 6. Make `plan` the safety gate for `apply`.
 7. Keep deletion opt-in and out of the first implementation unless explicitly requested.
+8. Use `tty-spinner` for long-running groups of independent provider operations.
+
+## Parallel Provider Operations
+
+The gem includes `tty-spinner` for visual progress during multi-step provider work. Zone workflows should split independent API work into bounded chunks, execute those chunks with worker threads, and attach one `TTY::Spinner` to each active worker or chunk.
+
+Use `TTY::Spinner::Multi` for managing multiple concurrent thread progress indicators:
+https://github.com/piotrmurach/tty-spinner#5-ttyspinnermulti-api
+
+Rules:
+
+- Use bounded concurrency; do not start one unbounded thread per DNS record.
+- Only parallelize independent API calls.
+- Preserve deterministic final output by collecting results and sorting/rendering after workers finish.
+- Keep `plan` rendering deterministic and mostly non-animated; spinners belong to long-running `export` and `apply` execution paths.
+- Provide a no-op or fake spinner in specs so test output is stable.
+- Aggregate worker errors and report which chunk/action failed.
+- Avoid parallel delete behavior until destructive operations are explicitly enabled and tested.
 
 ## Zone File Compatibility and Normalization
 
@@ -111,6 +129,7 @@ Establish a clean Ruby 4 baseline before changing CLI architecture.
      - `dry-validation`
      - `dns-zonefile`
      - `tsort`, because `sym` warns that `tsort` will no longer be bundled by default in Ruby 4.1
+     - `tty-spinner`
    - Development:
      - `aruba`
 5. Run the current suite.
@@ -451,6 +470,7 @@ dme zone export DOMAIN [--output=FILE] [--ttl=300] [--include-apex-ns]
 4. Write to stdout by default.
 5. Write to file when `--output` is provided.
 6. Print warnings to stderr, not stdout, so stdout remains pipe-safe.
+7. Use threaded chunks and `TTY::Spinner` when export requires multiple independent provider calls.
 
 ### Acceptance Criteria
 
@@ -540,6 +560,7 @@ dme zone apply FILE [--domain=DOMAIN] [--yes] [--delete]
 4. Execute creates and updates through existing client methods.
 5. Execute deletes only when explicitly enabled.
 6. Print a final summary.
+7. Split independent API operations into bounded worker-thread chunks and display a `TTY::Spinner` for each active worker/chunk.
 
 ### Safety Rules
 
@@ -550,6 +571,8 @@ dme zone apply FILE [--domain=DOMAIN] [--yes] [--delete]
 - Consider ordering:
   - create replacement records before deleting old records where safe
   - avoid CNAME conflicts by detecting incompatible desired state before apply
+- Parallelize only independent actions after dependency/conflict checks.
+- Keep execution summaries deterministic even when worker completion order varies.
 
 ### Acceptance Criteria
 
@@ -557,6 +580,8 @@ dme zone apply FILE [--domain=DOMAIN] [--yes] [--delete]
 - `apply` can run against a mocked client in specs.
 - Confirmation is tested through Aruba.
 - Partial failures report completed and failed actions.
+- Threaded execution has specs for successful chunks and failed chunks.
+- Spinner behavior is covered through injected fake/no-op spinner objects.
 
 ## Phase 10: Documentation and Migration Notes
 

--- a/docs/plans/02-plan-dry-cli-launcher.md
+++ b/docs/plans/02-plan-dry-cli-launcher.md
@@ -11,6 +11,7 @@
 ## Scope
 
 - Add `dry-cli`.
+- Include `tty-spinner` as a runtime dependency for later threaded zone export/apply progress reporting.
 - Add a `DnsMadeEasy::CLI::Commands` registry.
 - Add `DnsMadeEasy::CLI::Launcher`.
 - Add `DnsMadeEasy::CLI::Commands::Base`.

--- a/docs/plans/07-plan-zone-export.md
+++ b/docs/plans/07-plan-zone-export.md
@@ -23,6 +23,12 @@
 - Emit warnings listing omitted `HTTPRED` records.
 - Write zone text to stdout by default.
 - Write warnings to stderr so stdout remains pipe-safe.
+- When export requires multiple independent provider calls, split work into bounded worker-thread chunks.
+- Use one `TTY::Spinner` per active worker/chunk for interactive progress.
+- Use `TTY::Spinner::Multi` for concurrent thread progress:
+  https://github.com/piotrmurach/tty-spinner#5-ttyspinnermulti-api
+- Collect worker results and render final zone output deterministically after all workers finish.
+- Inject a fake/no-op spinner in specs so output remains stable.
 
 ## Live Integration Note
 
@@ -38,6 +44,8 @@ Live specs must be gated by `DNSMADEEASY_LIVE_TESTS=1` or equivalent and must on
 - Add unit specs for remote adapter conversion.
 - Add Aruba specs for export using a mocked client.
 - Add specs proving `HTTPRED` is omitted and warning text is emitted.
+- Add specs for chunked parallel execution with deterministic result ordering.
+- Add specs for failed worker chunks and aggregated error reporting.
 - Add optional live integration specs marked/skipped unless explicitly enabled.
 - Use `subject(:records)`, `subject(:output)`, and `its(:warnings)` where the object model supports it.
 
@@ -45,4 +53,6 @@ Live specs must be gated by `DNSMADEEASY_LIVE_TESTS=1` or equivalent and must on
 
 - `dme zone export example.com` produces deterministic zone output with mocked data.
 - Provider metadata is not serialized.
+- Independent provider reads can run concurrently with bounded worker threads.
+- Progress is displayed with `TTY::Spinner` during interactive export work.
 - `bundle exec rspec` passes without live credentials.

--- a/docs/plans/09-plan-zone-apply.md
+++ b/docs/plans/09-plan-zone-apply.md
@@ -14,6 +14,11 @@
 - Reuse the same planner used by `zone plan`.
 - Execute creates and updates through the existing API client.
 - Keep deletes opt-in.
+- Split independent API operations into bounded worker-thread chunks.
+- Use one `TTY::Spinner` per active worker/chunk for interactive progress.
+- Use `TTY::Spinner::Multi` for concurrent thread progress:
+  https://github.com/piotrmurach/tty-spinner#5-ttyspinnermulti-api
+- Keep final execution summaries deterministic even when worker completion order varies.
 
 ## Safety Rules
 
@@ -23,6 +28,8 @@
 - Require confirmation unless `--yes` is provided.
 - Fail before applying if parsing or validation fails.
 - Report partial failures clearly.
+- Parallelize only actions proven independent by the plan.
+- Aggregate worker errors by action/chunk.
 
 ## Live Integration Note
 
@@ -39,6 +46,9 @@ Live specs must only mutate predictable test records such as `_dnsmadeeasy-test.
 - Add Aruba specs for confirmation flow.
 - Add specs for `--yes`.
 - Add specs for delete refusal without `--delete`.
+- Add specs for threaded chunk execution.
+- Add specs using fake/no-op spinner objects.
+- Add specs proving final summaries are deterministic.
 - Add optional gated live integration specs for create/update/delete of test-owned records.
 - Use `subject(:result) { described_class.new(...).call }`.
 - Use `its(:applied_actions)`, `its(:failed_actions)`, and concise one-liners where useful.
@@ -47,5 +57,7 @@ Live specs must only mutate predictable test records such as `_dnsmadeeasy-test.
 
 - Apply executes the current plan.
 - Apply refuses destructive operations unless explicitly allowed.
+- Independent actions can run concurrently with bounded worker threads.
+- Progress is displayed with `TTY::Spinner` during interactive apply work.
 - Default test suite never touches live DNS.
 - `bundle exec rspec` passes.

--- a/exe/dme
+++ b/exe/dme
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'dnsmadeeasy/runner'
+require 'dnsmadeeasy'
 
-DnsMadeEasy::Runner.new(ARGV).execute!
+DnsMadeEasy::CLI::Launcher.new(ARGV.dup).execute!

--- a/lib/dnsmadeeasy.rb
+++ b/lib/dnsmadeeasy.rb
@@ -8,6 +8,7 @@ end
 require 'dnsmadeeasy/version'
 require 'dnsmadeeasy/credentials'
 require 'dnsmadeeasy/api/client'
+require 'dnsmadeeasy/cli/launcher'
 
 module DnsMadeEasy
   class Error < StandardError

--- a/lib/dnsmadeeasy/cli/commands.rb
+++ b/lib/dnsmadeeasy/cli/commands.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'dry/cli'
+
+module DnsMadeEasy
+  module CLI
+    module Commands
+      extend Dry::CLI::Registry
+    end
+  end
+end
+
+require 'dnsmadeeasy/cli/commands/base'
+require 'dnsmadeeasy/cli/commands/version'

--- a/lib/dnsmadeeasy/cli/commands/base.rb
+++ b/lib/dnsmadeeasy/cli/commands/base.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'dry/cli'
+
+module DnsMadeEasy
+  module CLI
+    module Commands
+      # Base class for dry-cli commands.
+      class Base < Dry::CLI::Command
+        private
+
+        def puts(*)
+          @out.puts(*)
+        end
+      end
+    end
+  end
+end

--- a/lib/dnsmadeeasy/cli/commands/version.rb
+++ b/lib/dnsmadeeasy/cli/commands/version.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'dnsmadeeasy/version'
+require 'dnsmadeeasy/cli/commands/base'
+
+module DnsMadeEasy
+  module CLI
+    # Registered dry-cli command classes.
+    module Commands
+      # Prints the gem version.
+      class Version < Base
+        desc 'Print version'
+
+        def call(*)
+          puts DnsMadeEasy::VERSION
+        end
+      end
+
+      register 'version', Version, aliases: %w[v -v --version]
+    end
+  end
+end

--- a/lib/dnsmadeeasy/cli/launcher.rb
+++ b/lib/dnsmadeeasy/cli/launcher.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'dry/cli'
+require 'dnsmadeeasy/version'
+require 'dnsmadeeasy/cli/commands'
+
+module DnsMadeEasy
+  module CLI
+    # Entrypoint used by the executable and in-process CLI specs.
+    class Launcher
+      attr_reader :argv, :stdin, :stdout, :stderr, :kernel
+
+      def initialize(argv, stdin = $stdin, stdout = $stdout, stderr = $stderr, kernel = Kernel)
+        @argv = argv
+        @stdin = stdin
+        @stdout = stdout
+        @stderr = stderr
+        @kernel = kernel
+      end
+
+      def execute!
+        command.call(arguments: argv, out: stdout, err: stderr)
+      rescue SystemExit => e
+        e.status
+      end
+
+      private
+
+      def command
+        @command ||= Dry::CLI.new(Commands)
+      end
+    end
+  end
+end

--- a/spec/lib/dnsmadeeasy/cli/aruba_spec.rb
+++ b/spec/lib/dnsmadeeasy/cli/aruba_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'dme CLI', type: :aruba do
+  before { setup_aruba }
+
+  describe 'version' do
+    subject(:output) { last_command_started.stdout }
+
+    before { run_command_and_stop('dme version') }
+
+    it { is_expected.to eq("#{DnsMadeEasy::VERSION}\n") }
+  end
+
+  describe 'help' do
+    subject(:output) { last_command_started.stderr }
+
+    before { run_command_and_stop('dme --help') }
+
+    it { is_expected.to include('Commands:') }
+    it { is_expected.to include('version') }
+  end
+end

--- a/spec/lib/dnsmadeeasy/cli/commands/version_spec.rb
+++ b/spec/lib/dnsmadeeasy/cli/commands/version_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DnsMadeEasy::CLI::Commands::Version do
+  describe '#call' do
+    subject(:command) { described_class.new }
+
+    let(:stdout) { StringIO.new }
+
+    before do
+      command.instance_variable_set(:@out, stdout)
+      command.call
+    end
+
+    its(:class) { should eq(described_class) }
+
+    describe 'output' do
+      subject(:output) { stdout.string }
+
+      it { is_expected.to eq("#{DnsMadeEasy::VERSION}\n") }
+    end
+  end
+end

--- a/spec/lib/dnsmadeeasy/cli/launcher_spec.rb
+++ b/spec/lib/dnsmadeeasy/cli/launcher_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+
+RSpec.describe DnsMadeEasy::CLI::Launcher do
+  describe '#execute!' do
+    subject(:execute) { launcher.execute! }
+
+    let(:stdin) { StringIO.new }
+    let(:stdout) { StringIO.new }
+    let(:stderr) { StringIO.new }
+    let(:launcher) { described_class.new(argv, stdin, stdout, stderr) }
+
+    context 'with version argument' do
+      let(:argv) { %w[version] }
+
+      before { execute }
+
+      describe 'stdout' do
+        subject(:output) { stdout.string }
+
+        it { is_expected.to eq("#{DnsMadeEasy::VERSION}\n") }
+      end
+
+      describe 'stderr' do
+        subject(:error_output) { stderr.string }
+
+        it { is_expected.to eq('') }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rspec'
 require 'rspec/its'
 require 'simplecov'
 require 'webmock/rspec'
+require 'aruba/rspec'
 
 SimpleCov.start
 
@@ -18,4 +19,11 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include Aruba::Api
+end
+
+Aruba.configure do |config|
+  config.command_launcher = :in_process
+  config.main_class = DnsMadeEasy::CLI::Launcher
 end


### PR DESCRIPTION
Plan 02 - dry-cli Launcher and Aruba Test Harness

Summary:
- Add dry-cli launcher, command registry, base command, and version command.
- Switch exe/dme to launch through DnsMadeEasy::CLI::Launcher.
- Configure Aruba in-process CLI specs.
- Add direct launcher, version command, and Aruba smoke specs for dme version and dme --help.
- Include tty-spinner as a runtime dependency for later threaded zone export/apply progress reporting.
- Update the zone-management plans to require bounded worker threads and TTY::Spinner::Multi for concurrent progress indicators.

TTY::Spinner::Multi reference:
https://github.com/piotrmurach/tty-spinner#5-ttyspinnermulti-api

Verification:
- bundle exec rspec
- bundle exec rubocop