### PR TITLE
04: Add zone record models

### DIFF
--- a/dnsmadeeasy.gemspec
+++ b/dnsmadeeasy.gemspec
@@ -70,6 +70,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'awesome_print'
   spec.add_dependency 'colored2'
   spec.add_dependency 'dry-cli'
+  spec.add_dependency 'dry-struct'
+  spec.add_dependency 'dry-types'
   spec.add_dependency 'hashie'
   spec.add_dependency 'sym'
   spec.add_dependency 'tsort'

--- a/lib/dnsmadeeasy.rb
+++ b/lib/dnsmadeeasy.rb
@@ -6,9 +6,13 @@ module DnsMadeEasy
 end
 
 require 'dnsmadeeasy/version'
+require 'dnsmadeeasy/types'
 require 'dnsmadeeasy/credentials'
 require 'dnsmadeeasy/api/client'
 require 'dnsmadeeasy/cli/launcher'
+require 'dnsmadeeasy/zone/record'
+require 'dnsmadeeasy/zone/provider_record'
+require 'dnsmadeeasy/zone/record_set'
 
 module DnsMadeEasy
   class Error < StandardError

--- a/lib/dnsmadeeasy/types.rb
+++ b/lib/dnsmadeeasy/types.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'dry/types'
+
+module DnsMadeEasy
+  # Shared dry-rb types used by value objects.
+  module Types
+    include Dry.Types()
+
+    DNS_RECORD_TYPES = %w[A AAAA CNAME MX NS PTR SPF SRV TXT].freeze
+
+    StrictString = Strict::String
+    NonEmptyString = StrictString.constrained(min_size: 1)
+    RecordType = StrictString.enum(*DNS_RECORD_TYPES)
+    Ttl = Coercible::Integer.constrained(gteq: 0)
+    OptionalInteger = Coercible::Integer.optional
+    OptionalString = StrictString.optional
+  end
+end

--- a/lib/dnsmadeeasy/zone/provider_record.rb
+++ b/lib/dnsmadeeasy/zone/provider_record.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'dry/struct'
+require 'dnsmadeeasy/types'
+require 'dnsmadeeasy/zone/record'
+
+module DnsMadeEasy
+  module Zone
+    # Associates provider metadata with a provider-neutral DNS record.
+    class ProviderRecord < Dry::Struct
+      transform_keys(&:to_sym)
+
+      attribute :record, Record
+      attribute :provider_id, Types::Coercible::Integer.optional.default(nil)
+      attribute :source_id, Types::OptionalString.default(nil)
+    end
+  end
+end

--- a/lib/dnsmadeeasy/zone/record.rb
+++ b/lib/dnsmadeeasy/zone/record.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'dry/struct'
+require 'dnsmadeeasy/types'
+
+module DnsMadeEasy
+  module Zone
+    # Provider-neutral DNS record value object.
+    class Record < Dry::Struct
+      transform_keys(&:to_sym)
+
+      attribute :owner, Types::NonEmptyString
+      attribute :type, Types::RecordType
+      attribute :value, Types::NonEmptyString
+      attribute :ttl, Types::Ttl.default(300)
+      attribute :priority, Types::OptionalInteger.default(nil)
+      attribute :weight, Types::OptionalInteger.default(nil)
+      attribute :port, Types::OptionalInteger.default(nil)
+
+      def sort_key
+        [
+          normalized_owner,
+          type_order,
+          type,
+          priority || -1,
+          weight || -1,
+          port || -1,
+          value,
+          ttl
+        ]
+      end
+
+      private
+
+      def normalized_owner
+        owner == '@' ? '' : owner
+      end
+
+      def type_order
+        Types::DNS_RECORD_TYPES.index(type) || Types::DNS_RECORD_TYPES.length
+      end
+    end
+  end
+end

--- a/lib/dnsmadeeasy/zone/record_set.rb
+++ b/lib/dnsmadeeasy/zone/record_set.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'dry/struct'
+require 'dnsmadeeasy/zone/record'
+
+module DnsMadeEasy
+  module Zone
+    # Deterministically ordered collection of zone records.
+    class RecordSet < Dry::Struct
+      transform_keys(&:to_sym)
+
+      attribute :records, Types::Array.of(Record).default([].freeze)
+
+      def sorted
+        records.sort_by(&:sort_key)
+      end
+
+      def include?(record)
+        records.include?(record)
+      end
+    end
+  end
+end

--- a/spec/lib/dns_made_easy/zone/provider_record_spec.rb
+++ b/spec/lib/dns_made_easy/zone/provider_record_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DnsMadeEasy::Zone::ProviderRecord do
+  describe '#initialize' do
+    subject(:provider_record) { described_class.new(record: record, provider_id: provider_id, source_id: source_id) }
+
+    let(:record) { DnsMadeEasy::Zone::Record.new(owner: 'www', type: 'A', value: '203.0.113.10') }
+    let(:provider_id) { 12_345 }
+    let(:source_id) { 'dns-made-easy' }
+
+    its(:record) { is_expected.to eq(record) }
+    its(:provider_id) { is_expected.to eq(12_345) }
+    its(:source_id) { is_expected.to eq('dns-made-easy') }
+
+    describe 'record equality' do
+      subject(:records_equal) { provider_record.record == other_provider_record.record }
+
+      let(:other_provider_record) do
+        described_class.new(record: record, provider_id: 67_890, source_id: 'other-source')
+      end
+
+      it { is_expected.to be(true) }
+    end
+  end
+end

--- a/spec/lib/dns_made_easy/zone/record_set_spec.rb
+++ b/spec/lib/dns_made_easy/zone/record_set_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DnsMadeEasy::Zone::RecordSet do
+  describe '#sorted' do
+    subject(:sorted_records) { record_set.sorted }
+
+    let(:record_set) { described_class.new(records: records) }
+    let(:apex_a_record) { DnsMadeEasy::Zone::Record.new(owner: '@', type: 'A', value: '203.0.113.10') }
+    let(:www_record) { DnsMadeEasy::Zone::Record.new(owner: 'www', type: 'CNAME', value: '@') }
+    let(:apex_mx_record) do
+      DnsMadeEasy::Zone::Record.new(owner: '@', type: 'MX', value: 'mail.example.com.', priority: 10)
+    end
+    let(:records) { [www_record, apex_mx_record, apex_a_record] }
+
+    it { is_expected.to eq([apex_a_record, apex_mx_record, www_record]) }
+  end
+
+  describe '#include?' do
+    subject(:record_set) { described_class.new(records: [record]) }
+
+    let(:record) { DnsMadeEasy::Zone::Record.new(owner: '@', type: 'A', value: '203.0.113.10') }
+
+    it { is_expected.to include(record) }
+  end
+end

--- a/spec/lib/dns_made_easy/zone/record_spec.rb
+++ b/spec/lib/dns_made_easy/zone/record_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DnsMadeEasy::Zone::Record do
+  describe '#initialize' do
+    subject(:record) { described_class.new(attributes) }
+
+    let(:attributes) do
+      {
+        owner: '@',
+        type: 'A',
+        value: '203.0.113.10',
+        ttl: 300
+      }
+    end
+
+    its(:owner) { is_expected.to eq('@') }
+    its(:type) { is_expected.to eq('A') }
+    its(:value) { is_expected.to eq('203.0.113.10') }
+    its(:ttl) { is_expected.to eq(300) }
+    its(:priority) { is_expected.to be_nil }
+
+    context 'with missing ttl' do
+      let(:attributes) do
+        {
+          owner: 'www',
+          type: 'CNAME',
+          value: '@'
+        }
+      end
+
+      its(:ttl) { is_expected.to eq(300) }
+    end
+
+    context 'with invalid type' do
+      let(:attributes) do
+        {
+          owner: '@',
+          type: 'HTTPRED',
+          value: 'https://example.com',
+          ttl: 300
+        }
+      end
+
+      it { expect { record }.to raise_error(Dry::Struct::Error, /invalid type/) }
+    end
+
+    context 'with invalid ttl' do
+      let(:attributes) do
+        {
+          owner: '@',
+          type: 'A',
+          value: '203.0.113.10',
+          ttl: -1
+        }
+      end
+
+      it { expect { record }.to raise_error(Dry::Struct::Error, /invalid type/) }
+    end
+
+    context 'with missing owner' do
+      let(:attributes) do
+        {
+          type: 'A',
+          value: '203.0.113.10',
+          ttl: 300
+        }
+      end
+
+      it { expect { record }.to raise_error(Dry::Struct::Error) }
+    end
+  end
+
+  describe '#sort_key' do
+    subject(:sort_key) { record.sort_key }
+
+    let(:record) do
+      described_class.new(
+        owner: '@',
+        type: 'MX',
+        value: 'mail.example.com.',
+        ttl: 300,
+        priority: 10
+      )
+    end
+
+    it { is_expected.to eq(['', 3, 'MX', 10, -1, -1, 'mail.example.com.', 300]) }
+  end
+end


### PR DESCRIPTION
Plan 04 - Zone Record Models

Summary:
- Add dry-types and dry-struct runtime dependencies.
- Add DnsMadeEasy::Types for shared validated value types.
- Add DnsMadeEasy::Zone::Record as a provider-neutral DNS record value object.
- Add DnsMadeEasy::Zone::ProviderRecord to associate provider IDs/source metadata with neutral records.
- Add DnsMadeEasy::Zone::RecordSet for deterministic record ordering and membership checks.
- Keep HTTPRED out of the standard zone record enum for v1 normalized zone-file behavior.

Verification:
- bundle exec rspec
- bundle exec rubocop
