### PR TITLE
06: Add canonical zone serializer and formatter

### DIFF
--- a/lib/dnsmadeeasy.rb
+++ b/lib/dnsmadeeasy.rb
@@ -13,7 +13,9 @@ require 'dnsmadeeasy/cli/launcher'
 require 'dnsmadeeasy/zone/record'
 require 'dnsmadeeasy/zone/provider_record'
 require 'dnsmadeeasy/zone/record_set'
+require 'dnsmadeeasy/zone/file'
 require 'dnsmadeeasy/zone/parser'
+require 'dnsmadeeasy/zone/serializer'
 
 module DnsMadeEasy
   class Error < StandardError

--- a/lib/dnsmadeeasy/cli/commands/zone.rb
+++ b/lib/dnsmadeeasy/cli/commands/zone.rb
@@ -3,6 +3,7 @@
 require 'dnsmadeeasy/cli/commands/base'
 require 'dnsmadeeasy/cli/message_helpers'
 require 'dnsmadeeasy/zone/parser'
+require 'dnsmadeeasy/zone/serializer'
 
 module DnsMadeEasy
   module CLI
@@ -18,7 +19,7 @@ module DnsMadeEasy
 
           def call(file:, **)
             configure_message_helpers
-            result = DnsMadeEasy::Zone::Parser.new(File.read(file)).call
+            result = DnsMadeEasy::Zone::Parser.new(::File.read(file)).call
 
             if result.success?
               record_count = result.value!.records.length
@@ -36,10 +37,37 @@ module DnsMadeEasy
             MessageHelpers.stderr = @err
           end
         end
+
+        # Formats a standard DNS zone file into canonical output.
+        class Format < Base
+          desc 'Format a DNS zone file'
+
+          argument :file, required: true, desc: 'Zone file path'
+
+          def call(file:, **)
+            configure_message_helpers
+            result = DnsMadeEasy::Zone::Parser.new(::File.read(file)).call
+
+            if result.success?
+              puts DnsMadeEasy::Zone::Serializer.new(result.value!)
+            else
+              MessageHelpers.error("Zone file is invalid.\n#{result.failure.join("\n")}")
+              raise ArgumentError, 'zone file is invalid'
+            end
+          end
+
+          private
+
+          def configure_message_helpers
+            MessageHelpers.stdout = @out
+            MessageHelpers.stderr = @err
+          end
+        end
       end
 
       register 'zone' do |prefix|
         prefix.register 'validate', Zone::Validate
+        prefix.register 'fmt', Zone::Format, aliases: ['format']
       end
     end
   end

--- a/lib/dnsmadeeasy/zone/file.rb
+++ b/lib/dnsmadeeasy/zone/file.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'dry/struct'
+require 'dnsmadeeasy/types'
+require 'dnsmadeeasy/zone/record_set'
+
+module DnsMadeEasy
+  module Zone
+    # Parsed zone-file document with metadata needed for canonical output.
+    class File < Dry::Struct
+      transform_keys(&:to_sym)
+
+      attribute :origin, Types::NonEmptyString
+      attribute :ttl, Types::Ttl.default(300)
+      attribute :record_set, RecordSet
+
+      def records
+        record_set.records
+      end
+
+      def sorted
+        record_set.sorted
+      end
+    end
+  end
+end

--- a/lib/dnsmadeeasy/zone/parser.rb
+++ b/lib/dnsmadeeasy/zone/parser.rb
@@ -2,6 +2,7 @@
 
 require 'dns/zonefile'
 require 'dry/monads'
+require 'dnsmadeeasy/zone/file'
 require 'dnsmadeeasy/zone/record'
 require 'dnsmadeeasy/zone/record_set'
 
@@ -28,11 +29,11 @@ module DnsMadeEasy
       end
 
       def call
-        zone = DNS::Zonefile.load(zone_text)
+        zone = DNS::Zonefile.load(parseable_zone_text)
         records, errors = build_records(zone)
         return Failure(errors) if errors.any?
 
-        Success(RecordSet.new(records: records))
+        Success(File.new(origin: zone_origin(zone), ttl: zone_ttl(zone), record_set: RecordSet.new(records: records)))
       rescue DNS::Zonefile::ParsingError, DNS::Zonefile::UnknownRecordType, Dry::Struct::Error => e
         Failure([e.message])
       end
@@ -40,6 +41,27 @@ module DnsMadeEasy
       private
 
       attr_reader :zone_text
+
+      def parseable_zone_text
+        return zone_text if zone_text.match?(/\bSOA\b/)
+
+        zone_lines = zone_text.lines
+        insertion_index = zone_lines.index { |line| !line.strip.start_with?('$') && !line.strip.empty? } || zone_lines.length
+        zone_lines.insert(insertion_index, synthetic_soa_line)
+        zone_lines.join
+      end
+
+      def synthetic_soa_line
+        "@ IN SOA ns.#{origin_from_text} hostmaster.#{origin_from_text} ( 1 1d 1d 4W #{ttl_from_text} )\n"
+      end
+
+      def origin_from_text
+        zone_text[/^\$ORIGIN\s+(\S+)/, 1] || 'example.invalid.'
+      end
+
+      def ttl_from_text
+        zone_text[/^\$TTL\s+(\d+)/, 1] || 300
+      end
 
       def build_records(zone)
         origin = zone_origin(zone)
@@ -57,6 +79,10 @@ module DnsMadeEasy
 
       def zone_origin(zone)
         zone.soa&.origin || '.'
+      end
+
+      def zone_ttl(zone)
+        zone.soa&.ttl || 300
       end
 
       def build_record(provider_record, record_type, origin)

--- a/lib/dnsmadeeasy/zone/serializer.rb
+++ b/lib/dnsmadeeasy/zone/serializer.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'dnsmadeeasy/zone/file'
+
+module DnsMadeEasy
+  module Zone
+    # Emits deterministic, normalized zone-file text.
+    class Serializer
+      def initialize(zone_file, omit_apex_ns: true)
+        @zone_file = zone_file
+        @omit_apex_ns = omit_apex_ns
+      end
+
+      def to_s
+        lines = [
+          "$ORIGIN #{zone_file.origin}",
+          "$TTL #{zone_file.ttl}",
+          ''
+        ]
+        lines.concat(serialized_records)
+        "#{lines.join("\n")}\n"
+      end
+
+      private
+
+      attr_reader :zone_file,
+                  :omit_apex_ns
+
+      def serialized_records
+        grouped_records.flat_map.with_index do |records, index|
+          lines = records.map { |record| serialize_record(record) }
+          index.zero? ? lines : [''] + lines
+        end
+      end
+
+      def grouped_records
+        serializable_records.chunk { |record| record_group(record) }.map(&:last)
+      end
+
+      def serializable_records
+        zone_file.records
+                 .reject { |record| omit_apex_ns && record.owner == '@' && record.type == 'NS' }
+                 .sort_by { |record| serializer_sort_key(record) }
+      end
+
+      def record_group(record)
+        case record.type
+        when 'MX'
+          :mail
+        when 'TXT', 'SPF'
+          :text
+        else
+          :address
+        end
+      end
+
+      def serializer_sort_key(record)
+        [
+          serializer_type_group(record),
+          normalized_owner(record.owner),
+          record.type,
+          record.priority || -1,
+          record.value,
+          record.ttl
+        ]
+      end
+
+      def serializer_type_group(record)
+        case record.type
+        when 'A', 'AAAA', 'CNAME', 'NS', 'PTR'
+          0
+        when 'MX', 'SRV'
+          1
+        when 'TXT', 'SPF'
+          2
+        else
+          3
+        end
+      end
+
+      def normalized_owner(owner)
+        owner == '@' ? '' : owner
+      end
+
+      def serialize_record(record)
+        [record.owner.ljust(8), 'IN', record.type.ljust(7), record_payload(record)].join(' ')
+      end
+
+      def record_payload(record)
+        case record.type
+        when 'MX'
+          "#{record.priority} #{record.value}"
+        when 'SRV'
+          "#{record.priority} #{record.weight} #{record.port} #{record.value}"
+        when 'TXT', 'SPF'
+          quote_text(record.value)
+        else
+          record.value
+        end
+      end
+
+      def quote_text(value)
+        %("#{value}")
+      end
+    end
+  end
+end

--- a/spec/fixtures/zones/formatted.zone
+++ b/spec/fixtures/zones/formatted.zone
@@ -1,0 +1,9 @@
+$ORIGIN example.com.
+$TTL 300
+
+@        IN A       203.0.113.10
+www      IN CNAME   @
+
+@        IN MX      10 mail.example.com.
+
+@        IN TXT     "v=spf1 include:_spf.google.com ~all"

--- a/spec/lib/dns_made_easy/cli/zone_aruba_spec.rb
+++ b/spec/lib/dns_made_easy/cli/zone_aruba_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'dme zone', type: :aruba do
   before do
     setup_aruba
     write_file('valid.zone', File.read('spec/fixtures/zones/valid.zone'))
+    write_file('formatted.zone', File.read('spec/fixtures/zones/formatted.zone'))
     write_file('invalid.zone', File.read('spec/fixtures/zones/invalid.zone'))
     write_file('unsupported.zone', File.read('spec/fixtures/zones/unsupported.zone'))
   end
@@ -33,5 +34,21 @@ RSpec.describe 'dme zone', type: :aruba do
     before { run_command_and_stop('dme zone validate unsupported.zone') }
 
     it { is_expected.to include('Unsupported DNS record type: CAA') }
+  end
+
+  describe 'fmt valid zone file' do
+    subject(:output) { last_command_started.stdout }
+
+    before { run_command_and_stop('dme zone fmt valid.zone') }
+
+    it { is_expected.to eq(File.read('spec/fixtures/zones/formatted.zone')) }
+  end
+
+  describe 'format alias' do
+    subject(:output) { last_command_started.stdout }
+
+    before { run_command_and_stop('dme zone format formatted.zone') }
+
+    it { is_expected.to eq(File.read('spec/fixtures/zones/formatted.zone')) }
   end
 end

--- a/spec/lib/dns_made_easy/zone/parser_spec.rb
+++ b/spec/lib/dns_made_easy/zone/parser_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe DnsMadeEasy::Zone::Parser do
 
       it { is_expected.to be_success }
 
+      describe 'zone file' do
+        subject(:zone_file) { result.value! }
+
+        its(:origin) { is_expected.to eq('example.com.') }
+        its(:ttl) { is_expected.to eq(300) }
+      end
+
       describe 'records' do
         subject(:records) { result.value!.records }
 

--- a/spec/lib/dns_made_easy/zone/serializer_spec.rb
+++ b/spec/lib/dns_made_easy/zone/serializer_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DnsMadeEasy::Zone::Serializer do
+  describe '#to_s' do
+    subject(:serialized_zone) { described_class.new(zone_file).to_s }
+
+    let(:zone_file) do
+      DnsMadeEasy::Zone::File.new(origin: 'example.com.', ttl: 300, record_set: record_set)
+    end
+    let(:record_set) { DnsMadeEasy::Zone::RecordSet.new(records: records) }
+    let(:records) do
+      [
+        DnsMadeEasy::Zone::Record.new(owner: 'www', type: 'CNAME', value: '@'),
+        DnsMadeEasy::Zone::Record.new(owner: '@', type: 'TXT', value: 'v=spf1 include:_spf.google.com ~all'),
+        DnsMadeEasy::Zone::Record.new(owner: '@', type: 'MX', value: 'mail.example.com.', priority: 10),
+        DnsMadeEasy::Zone::Record.new(owner: '@', type: 'A', value: '203.0.113.10')
+      ]
+    end
+
+    it { is_expected.to eq(File.read('spec/fixtures/zones/formatted.zone')) }
+
+    context 'with apex and delegated NS records' do
+      let(:records) do
+        [
+          DnsMadeEasy::Zone::Record.new(owner: '@', type: 'NS', value: 'ns1.dnsmadeeasy.com.'),
+          DnsMadeEasy::Zone::Record.new(owner: 'delegated', type: 'NS', value: 'ns1.example.net.')
+        ]
+      end
+
+      it { is_expected.not_to include('@        IN NS') }
+      it { is_expected.to include('delegated IN NS      ns1.example.net.') }
+    end
+  end
+
+  describe 'idempotency' do
+    subject(:reformatted_zone) do
+      first_parse_result = DnsMadeEasy::Zone::Parser.new(File.read('spec/fixtures/zones/formatted.zone')).call
+      serialized_zone = described_class.new(first_parse_result.value!).to_s
+      second_parse_result = DnsMadeEasy::Zone::Parser.new(serialized_zone).call
+
+      described_class.new(second_parse_result.value!).to_s
+    end
+
+    it { is_expected.to eq(File.read('spec/fixtures/zones/formatted.zone')) }
+  end
+end


### PR DESCRIPTION
Plan 06 - Canonical Zone Serializer and Formatter

Summary:
- Add DnsMadeEasy::Zone::File to preserve origin, TTL, and records for canonical output.
- Add DnsMadeEasy::Zone::Serializer for deterministic normalized zone-file output.
- Add dme zone fmt FILE and dme zone format FILE alias.
- Emit $ORIGIN, $TTL, explicit owners, @ apex records, aligned whitespace, and deterministic grouping.
- Omit provider-managed SOA and omit apex NS records by default while preserving delegated NS records.
- Preserve parse/serialize/parse/serialize idempotency for canonical files.
- Continue using dns-zonefile as the parsing adapter and dry-monads for parse failures.

References:
- RFC 1033 / RFC 1035 zone-file semantics: RR fields are whitespace-separated, @ denotes origin, semicolons start comments, and parentheses may group multiline data.
- Wikipedia Zone file page used as secondary reference for common zone-file conventions.

Verification:
- bundle exec rspec
- bundle exec rubocop
