### PR TITLE
07: Export DNS Made Easy records as canonical zone files

### DIFF
--- a/lib/dnsmadeeasy.rb
+++ b/lib/dnsmadeeasy.rb
@@ -15,6 +15,8 @@ require 'dnsmadeeasy/zone/provider_record'
 require 'dnsmadeeasy/zone/record_set'
 require 'dnsmadeeasy/zone/file'
 require 'dnsmadeeasy/zone/parser'
+require 'dnsmadeeasy/zone/remote_adapter'
+require 'dnsmadeeasy/zone/remote_records'
 require 'dnsmadeeasy/zone/serializer'
 
 module DnsMadeEasy

--- a/lib/dnsmadeeasy/cli/commands/zone.rb
+++ b/lib/dnsmadeeasy/cli/commands/zone.rb
@@ -2,8 +2,11 @@
 
 require 'dnsmadeeasy/cli/commands/base'
 require 'dnsmadeeasy/cli/message_helpers'
+require 'json'
 require 'dnsmadeeasy/zone/parser'
+require 'dnsmadeeasy/zone/remote_adapter'
 require 'dnsmadeeasy/zone/serializer'
+require 'yaml'
 
 module DnsMadeEasy
   module CLI
@@ -63,11 +66,108 @@ module DnsMadeEasy
             MessageHelpers.stderr = @err
           end
         end
+
+        # Exports DNS Made Easy records as canonical zone-file text.
+        class Export < Base
+          desc 'Export DNS Made Easy records as a canonical zone file'
+
+          argument :domain, required: true, desc: 'Domain name'
+
+          option :format, aliases: ['f'], values: %w[rfc json yaml], required: false,
+                          desc: 'Export format: rfc, json, or yaml'
+          option :output, required: false, desc: 'Output file path'
+          option :ttl, required: false, desc: 'Default TTL for records missing provider TTL'
+          option :include_apex_ns, type: :boolean, default: false, desc: 'Include apex NS records'
+
+          def call(**options)
+            configure_message_helpers
+            configure_authentication(credentials: options[:credentials], api_key: options[:api_key],
+                                     api_secret: options[:api_secret])
+
+            domain = options.fetch(:domain)
+            export_ttl = options[:ttl] || 300
+            result = DnsMadeEasy::Zone::RemoteAdapter.new(
+              DnsMadeEasy.client.records_for(domain),
+              domain: domain,
+              default_ttl: export_ttl
+            ).call
+
+            if result.success?
+              export_records(
+                domain,
+                result.value!,
+                format: options[:format] || 'rfc',
+                output: options[:output],
+                ttl: export_ttl,
+                include_apex_ns: options[:include_apex_ns]
+              )
+            else
+              MessageHelpers.error("Zone export failed.\n#{result.failure.join("\n")}")
+              raise ArgumentError, 'zone export failed'
+            end
+          end
+
+          private
+
+          def export_records(domain, remote_records, format:, output:, ttl:, include_apex_ns:)
+            remote_records.warnings.each { |warning| warn warning }
+            zone_text = export_text(domain, remote_records, format: format, ttl: ttl, include_apex_ns: include_apex_ns)
+
+            output ? ::File.write(output, zone_text) : puts(zone_text)
+          end
+
+          def export_text(domain, remote_records, format:, ttl:, include_apex_ns:)
+            zone_file = zone_file(domain, remote_records, ttl: ttl)
+
+            case format
+            when 'json'
+              JSON.pretty_generate(export_hash(zone_file))
+            when 'yaml'
+              export_hash(zone_file).to_yaml
+            else
+              DnsMadeEasy::Zone::Serializer.new(zone_file, omit_apex_ns: !include_apex_ns).to_s
+            end
+          end
+
+          def zone_file(domain, remote_records, ttl:)
+            DnsMadeEasy::Zone::File.new(
+              origin: "#{domain.delete_suffix('.')}.",
+              ttl: ttl,
+              record_set: remote_records.record_set
+            )
+          end
+
+          def export_hash(zone_file)
+            {
+              'origin' => zone_file.origin,
+              'ttl' => zone_file.ttl,
+              'records' => zone_file.sorted.map { |record| record_hash(record) }
+            }
+          end
+
+          def record_hash(record)
+            {
+              'owner' => record.owner,
+              'type' => record.type,
+              'value' => record.value,
+              'ttl' => record.ttl,
+              'priority' => record.priority,
+              'weight' => record.weight,
+              'port' => record.port
+            }.compact
+          end
+
+          def configure_message_helpers
+            MessageHelpers.stdout = @out
+            MessageHelpers.stderr = @err
+          end
+        end
       end
 
       register 'zone' do |prefix|
         prefix.register 'validate', Zone::Validate
         prefix.register 'fmt', Zone::Format, aliases: ['format']
+        prefix.register 'export', Zone::Export
       end
     end
   end

--- a/lib/dnsmadeeasy/zone/remote_adapter.rb
+++ b/lib/dnsmadeeasy/zone/remote_adapter.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dnsmadeeasy/zone/provider_record'
+require 'dnsmadeeasy/zone/record'
+require 'dnsmadeeasy/zone/remote_records'
+
+module DnsMadeEasy
+  module Zone
+    # Converts DNS Made Easy API record hashes into provider-neutral zone records.
+    class RemoteAdapter
+      include Dry::Monads[:result]
+
+      SUPPORTED_RECORD_TYPES = Types::DNS_RECORD_TYPES.freeze
+      SOURCE_ID = 'dns-made-easy'
+
+      def initialize(response, domain:, default_ttl: 300)
+        @response = response
+        @domain = domain
+        @default_ttl = default_ttl
+      end
+
+      def call
+        provider_records = []
+        warnings = []
+
+        remote_records.each do |remote_record|
+          if remote_record['type'] == 'HTTPRED'
+            warnings << omitted_httpred_warning(remote_record)
+          elsif SUPPORTED_RECORD_TYPES.include?(remote_record['type'])
+            provider_records << provider_record(remote_record)
+          else
+            return Failure(["Unsupported DNS Made Easy record type: #{remote_record['type']}"])
+          end
+        end
+
+        Success(RemoteRecords.new(provider_records: provider_records, warnings: warnings))
+      rescue Dry::Struct::Error => e
+        Failure([e.message])
+      end
+
+      private
+
+      attr_reader :response,
+                  :domain,
+                  :default_ttl
+
+      def remote_records
+        response.fetch('data', [])
+      end
+
+      def provider_record(remote_record)
+        ProviderRecord.new(
+          record: zone_record(remote_record),
+          provider_id: remote_record['id'],
+          source_id: SOURCE_ID
+        )
+      end
+
+      def zone_record(remote_record)
+        Record.new(
+          owner: owner(remote_record),
+          type: remote_record['type'],
+          value: remote_record['value'],
+          ttl: remote_record['ttl'] || default_ttl,
+          priority: remote_record['mxLevel'] || remote_record['priority'],
+          weight: remote_record['weight'],
+          port: remote_record['port']
+        )
+      end
+
+      def owner(remote_record)
+        name = remote_record['name'].to_s
+        return '@' if name.empty? || name == domain || name == domain.delete_suffix('.')
+
+        name.delete_suffix(".#{domain.delete_suffix('.')}")
+      end
+
+      def omitted_httpred_warning(remote_record)
+        record_name = remote_record['name'].to_s.empty? ? '@' : remote_record['name']
+        "Omitted HTTPRED record #{record_name} -> #{remote_record['value']}"
+      end
+    end
+  end
+end

--- a/lib/dnsmadeeasy/zone/remote_records.rb
+++ b/lib/dnsmadeeasy/zone/remote_records.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'dry/struct'
+require 'dnsmadeeasy/types'
+require 'dnsmadeeasy/zone/provider_record'
+require 'dnsmadeeasy/zone/record_set'
+
+module DnsMadeEasy
+  module Zone
+    # Provider records plus non-fatal warnings from remote conversion.
+    class RemoteRecords < Dry::Struct
+      transform_keys(&:to_sym)
+
+      attribute :provider_records, Types::Array.of(ProviderRecord).default([].freeze)
+      attribute :warnings, Types::Array.of(Types::StrictString).default([].freeze)
+
+      def records
+        provider_records.map(&:record)
+      end
+
+      def record_set
+        RecordSet.new(records: records)
+      end
+    end
+  end
+end

--- a/spec/lib/dns_made_easy/cli/zone_aruba_spec.rb
+++ b/spec/lib/dns_made_easy/cli/zone_aruba_spec.rb
@@ -1,14 +1,34 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'json'
+require 'yaml'
 
 RSpec.describe 'dme zone', type: :aruba do
   before do
     setup_aruba
+    allow(DnsMadeEasy).to receive(:client).and_return(client)
     write_file('valid.zone', File.read('spec/fixtures/zones/valid.zone'))
     write_file('formatted.zone', File.read('spec/fixtures/zones/formatted.zone'))
     write_file('invalid.zone', File.read('spec/fixtures/zones/invalid.zone'))
     write_file('unsupported.zone', File.read('spec/fixtures/zones/unsupported.zone'))
+  end
+
+  let(:client) do
+    instance_double(
+      DnsMadeEasy::Api::Client,
+      records_for: {
+        'data' => [
+          { 'id' => 1, 'name' => '', 'type' => 'A', 'value' => '203.0.113.10', 'ttl' => 300 },
+          { 'id' => 2, 'name' => 'www', 'type' => 'CNAME', 'value' => '@', 'ttl' => 300 },
+          { 'id' => 3, 'name' => '', 'type' => 'MX', 'value' => 'mail.example.com.', 'mxLevel' => 10, 'ttl' => 300 },
+          { 'id' => 4, 'name' => '', 'type' => 'NS', 'value' => 'ns1.dnsmadeeasy.com.', 'ttl' => 300 },
+          { 'id' => 5, 'name' => 'delegated', 'type' => 'NS', 'value' => 'ns1.example.net.', 'ttl' => 300 },
+          { 'id' => 6, 'name' => '', 'type' => 'TXT', 'value' => 'v=spf1 include:_spf.google.com ~all', 'ttl' => 300 },
+          { 'id' => 7, 'name' => 'redirect', 'type' => 'HTTPRED', 'value' => 'https://example.com/' }
+        ]
+      }
+    )
   end
 
   describe 'validate valid zone file' do
@@ -50,5 +70,74 @@ RSpec.describe 'dme zone', type: :aruba do
     before { run_command_and_stop('dme zone format formatted.zone') }
 
     it { is_expected.to eq(File.read('spec/fixtures/zones/formatted.zone')) }
+  end
+
+  describe 'export' do
+    subject(:output) { last_command_started.stdout }
+
+    before do
+      run_command_and_stop('dme zone export example.com --api-key=cli-key --api-secret=cli-secret')
+    end
+
+    it { is_expected.to include('$ORIGIN example.com.') }
+    it { is_expected.to include('@        IN A       203.0.113.10') }
+    it { is_expected.to include('delegated IN NS      ns1.example.net.') }
+    it { is_expected.not_to include('HTTPRED') }
+    it { is_expected.not_to include('ns1.dnsmadeeasy.com') }
+  end
+
+  describe 'export warnings' do
+    subject(:error_output) { last_command_started.stderr }
+
+    before do
+      run_command_and_stop('dme zone export example.com --api-key=cli-key --api-secret=cli-secret')
+    end
+
+    it { is_expected.to include('Omitted HTTPRED record redirect -> https://example.com/') }
+  end
+
+  describe 'export with apex NS records' do
+    subject(:output) { last_command_started.stdout }
+
+    before do
+      run_command_and_stop('dme zone export example.com --include-apex-ns --api-key=cli-key --api-secret=cli-secret')
+    end
+
+    it { is_expected.to include('@        IN NS      ns1.dnsmadeeasy.com.') }
+  end
+
+  describe 'export to output file' do
+    subject(:output_file) { read('export.zone') }
+
+    before do
+      run_command_and_stop('dme zone export example.com --output=export.zone --api-key=cli-key --api-secret=cli-secret')
+    end
+
+    it { is_expected.to include('$ORIGIN example.com.') }
+    it { is_expected.to include('@        IN A       203.0.113.10') }
+  end
+
+  describe 'export as json' do
+    subject(:parsed_output) { JSON.parse(last_command_started.stdout) }
+
+    before do
+      run_command_and_stop('dme zone export example.com -f json --api-key=cli-key --api-secret=cli-secret')
+    end
+
+    its(['origin']) { is_expected.to eq('example.com.') }
+    its(['ttl']) { is_expected.to eq(300) }
+    its(['records']) { is_expected.to include('owner' => '@', 'type' => 'A', 'value' => '203.0.113.10', 'ttl' => 300) }
+  end
+
+  describe 'export as yaml' do
+    subject(:parsed_output) { YAML.safe_load(last_command_started.stdout) }
+
+    before do
+      run_command_and_stop('dme zone export example.com --format=yaml --api-key=cli-key --api-secret=cli-secret')
+    end
+
+    its(['origin']) { is_expected.to eq('example.com.') }
+    its(['ttl']) { is_expected.to eq(300) }
+    its(['records']) { is_expected.to include('owner' => '@', 'type' => 'A', 'value' => '203.0.113.10', 'ttl' => 300) }
   end
 end

--- a/spec/lib/dns_made_easy/zone/remote_adapter_spec.rb
+++ b/spec/lib/dns_made_easy/zone/remote_adapter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DnsMadeEasy::Zone::RemoteAdapter do
+  describe '#call' do
+    subject(:result) { described_class.new(response, domain: domain, default_ttl: 300).call }
+
+    let(:domain) { 'example.com' }
+    let(:response) do
+      {
+        'data' => [
+          { 'id' => 1, 'name' => '', 'type' => 'A', 'value' => '203.0.113.10', 'ttl' => 300 },
+          { 'id' => 2, 'name' => 'www', 'type' => 'CNAME', 'value' => '@' },
+          { 'id' => 3, 'name' => '', 'type' => 'MX', 'value' => 'mail.example.com.', 'mxLevel' => 10 },
+          { 'id' => 4, 'name' => 'redirect', 'type' => 'HTTPRED', 'value' => 'https://example.com/' }
+        ]
+      }
+    end
+
+    it { is_expected.to be_success }
+
+    describe 'remote records' do
+      subject(:remote_records) { result.value! }
+
+      its(:warnings) { is_expected.to include('Omitted HTTPRED record redirect -> https://example.com/') }
+
+      describe 'records' do
+        subject(:records) { remote_records.records }
+
+        it { is_expected.to include(DnsMadeEasy::Zone::Record.new(owner: '@', type: 'A', value: '203.0.113.10')) }
+        it { is_expected.to include(DnsMadeEasy::Zone::Record.new(owner: 'www', type: 'CNAME', value: '@')) }
+        it { is_expected.to include(DnsMadeEasy::Zone::Record.new(owner: '@', type: 'MX', value: 'mail.example.com.', priority: 10)) }
+        it { is_expected.not_to include(have_attributes(type: 'HTTPRED')) }
+      end
+
+      describe 'provider record' do
+        subject(:provider_record) { remote_records.provider_records.first }
+
+        its(:provider_id) { is_expected.to eq(1) }
+        its(:source_id) { is_expected.to eq('dns-made-easy') }
+      end
+    end
+
+    context 'with an unsupported provider record type' do
+      let(:response) { { 'data' => [{ 'id' => 5, 'name' => '@', 'type' => 'CAA', 'value' => '0 issue "letsencrypt.org"' }] } }
+
+      it { is_expected.to be_failure }
+
+      describe 'errors' do
+        subject(:errors) { result.failure }
+
+        it { is_expected.to include('Unsupported DNS Made Easy record type: CAA') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Plan 07 - Remote Adapter and Zone Export

Summary:
- Add DNS Made Easy remote record adapter that converts provider responses into internal zone records.
- Preserve provider IDs/source metadata separately from exported records.
- Omit HTTPRED records from RFC zone output and warn on stderr.
- Add dme zone export DOMAIN with --output, --ttl, --include-apex-ns, and -f/--format rfc|json|yaml.
- Keep RFC zone text as the default export format and stdout pipe-safe.
- Serialize exported records through the canonical formatter.

References:
- RFC 1035 section 5 master-file semantics used for RFC export format.
- RFC 1033 and the Zone file reference inform @ origin, TTL, whitespace, comments, and RR field conventions.

Verification:
- bundle exec rspec
- bundle exec rubocop
