### PR TITLE
Normalize quoted DNS Made Easy TXT values

### DIFF
--- a/lib/dnsmadeeasy/zone/remote_adapter.rb
+++ b/lib/dnsmadeeasy/zone/remote_adapter.rb
@@ -61,7 +61,7 @@ module DnsMadeEasy
         Record.new(
           owner: owner(remote_record),
           type: remote_record['type'],
-          value: remote_record['value'],
+          value: value(remote_record),
           ttl: remote_record['ttl'] || default_ttl,
           priority: remote_record['mxLevel'] || remote_record['priority'],
           weight: remote_record['weight'],
@@ -74,6 +74,14 @@ module DnsMadeEasy
         return '@' if name.empty? || name == domain || name == domain.delete_suffix('.')
 
         name.delete_suffix(".#{domain.delete_suffix('.')}")
+      end
+
+      def value(remote_record)
+        record_value = remote_record['value']
+        return record_value unless remote_record['type'] == 'TXT'
+        return record_value unless record_value.start_with?('"') && record_value.end_with?('"')
+
+        record_value[1...-1]
       end
 
       def omitted_httpred_warning(remote_record)

--- a/spec/lib/dns_made_easy/zone/remote_adapter_spec.rb
+++ b/spec/lib/dns_made_easy/zone/remote_adapter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe DnsMadeEasy::Zone::RemoteAdapter do
           { 'id' => 1, 'name' => '', 'type' => 'A', 'value' => '203.0.113.10', 'ttl' => 300 },
           { 'id' => 2, 'name' => 'www', 'type' => 'CNAME', 'value' => '@' },
           { 'id' => 3, 'name' => '', 'type' => 'MX', 'value' => 'mail.example.com.', 'mxLevel' => 10 },
+          { 'id' => 4, 'name' => '_dmarc', 'type' => 'TXT', 'value' => '"v=DMARC1; p=none;"' },
           { 'id' => 4, 'name' => 'redirect', 'type' => 'HTTPRED', 'value' => 'https://example.com/' }
         ]
       }
@@ -31,6 +32,7 @@ RSpec.describe DnsMadeEasy::Zone::RemoteAdapter do
         it { is_expected.to include(DnsMadeEasy::Zone::Record.new(owner: '@', type: 'A', value: '203.0.113.10')) }
         it { is_expected.to include(DnsMadeEasy::Zone::Record.new(owner: 'www', type: 'CNAME', value: '@')) }
         it { is_expected.to include(DnsMadeEasy::Zone::Record.new(owner: '@', type: 'MX', value: 'mail.example.com.', priority: 10)) }
+        it { is_expected.to include(DnsMadeEasy::Zone::Record.new(owner: '_dmarc', type: 'TXT', value: 'v=DMARC1; p=none;')) }
         it { is_expected.not_to include(have_attributes(type: 'HTTPRED')) }
       end
 


### PR DESCRIPTION
During the live zone apply verification for email.qualified.at, DNS Made Easy returned TXT record values wrapped in presentation quotes. That made exported zone files render as double-quoted TXT values and caused `dme zone plan` to keep reporting quote-only TXT updates after a successful apply.

Changes:
- Normalize DNS Made Easy TXT API values by stripping one wrapping quote pair at the remote adapter boundary.
- Add a regression example for quoted TXT values.

Verification:
- `bundle exec rspec` - 274 examples, 0 failures, 92.99% line coverage.
- `bundle exec rubocop` - no offenses.
- `bundle exec dme zone plan email.qualified.at.resend.formatted.zone --domain=email.qualified.at` now reports `No changes.`.