### PR TITLE
Require DOMAIN FILE arguments for zone plan/apply (v1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ click                                IN CNAME   links.mailer.example.net.
 send                                 IN MX      10 feedback-smtp.us-east-1.amazonses.com.
 
 _dmarc                               IN TXT     "v=DMARC1; p=none;"
-mailer._domainkey                    IN TXT     "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7abc123...AQAB"
+mailer._domainkey                    IN TXT     "p=MIGfMA0GCSqGSIb3DQE7abc123...AQAB"
 send                                 IN TXT     "v=spf1 include:amazonses.com ~all"
 ```
 
@@ -360,12 +360,12 @@ Once you have the key and the secret, you have several choices:
 
   ```ruby
   require 'dnsmadeeasy'
-
+  
   DnsMadeEasy.configure do |config|
     config.api_key = 'XXXX'
     config.api_secret = 'YYYY'
   end
-
+  
   DnsMadeEasy.domains.data.first.name #=> 'moo.gamespot.com'
   ```
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
-# ADnsMadeEasy (`dmez`)
+# DnsMadeEasy (`dmez`)
 
-[![Gem Version](https://badge.fury.io/rb/dnsmadeeasy.svg?icon=si%3Arubygems)](https://badge.fury.io/rb/dnsmadeeasy)&nbsp;![coverage](docs/badges/coverage_badge.svg)&nbsp;![Gem Total Downloads](https://img.shields.io/gem/dt/dnsmadeeasy?style=for-the-badge&logoSize=auto)
-
+[![Gem Version](https://badge.fury.io/rb/dnsmadeeasy.svg?icon=si%3Arubygems)](https://badge.fury.io/rb/dnsmadeeasy) ![coverage](docs/badges/coverage_badge.svg) ![Gem Total Downloads](https://img.shields.io/gem/dt/dnsmadeeasy?style=for-the-badge&logoSize=auto)
 
 ## Ruby Client API Library Supporting Rest API SDK V2.0
 
 ### Gem Version 1.0 Supporting Zone Exports, Formatting, Plan, Apply
 
-
-
 > [!IMPORTANT]
 >
 > This gem is not backwards compatible with the previous version. It has been updated to work with DNS zone files and follow Terraform's pattern of the `read` → `plan` → `apply` loop. The old `dme` executable is deprecated in favor of `dmez`.
 
-------
+______________________________________________________________________
 
 This gem ships two things:
 
@@ -94,28 +91,29 @@ A real-world export looks like this:
 $ORIGIN example.com.
 $TTL 60
 
-@        300 IN A       151.101.3.52
-@        300 IN A       151.101.67.52
-@        300 IN ANAME   t.sni.global.fastly.net.
-*        300 IN CNAME   t.sni.global.fastly.net.
-_acme-challenge IN CNAME   validation-abc123.acme-validations.example.net.
-dev      IN A       127.0.0.1
-mail._domainkey IN CNAME   mail.domainkey.abc123.mailprovider.example.net.
-ssh      300 IN A       203.0.113.22
+@                                300 IN A       151.101.3.52
+@                                300 IN A       151.101.67.52
+@                                300 IN ANAME   t.sni.global.fastly.net.
+*                                300 IN CNAME   t.sni.global.fastly.net.
+_acme-challenge                      IN CNAME   validation-abc123.acme-validations.example.net.
+dev                                  IN A       127.0.0.1
+mail._domainkey                      IN CNAME   mail.domainkey.abc123.mailprovider.example.net.
+ssh                              300 IN A       203.0.113.22
 
-@        IN MX      10 mail.protonmail.ch.
-@        IN MX      20 mailsec.protonmail.ch.
+@                                    IN MX      10 mail.protonmail.ch.
+@                                    IN MX      20 mailsec.protonmail.ch.
 
-_imaps._tcp 1800 IN SRV     0 1 993 imap.fastmail.com.
-_submission._tcp 1800 IN SRV     0 1 587 smtp.fastmail.com.
+_imaps._tcp                     1800 IN SRV     0 1 993 imap.fastmail.com.
+_submission._tcp                1800 IN SRV     0 1 587 smtp.fastmail.com.
 
-@        IN TXT     "v=spf1 include:_spf.protonmail.ch ~all"
-@        IN TXT     "google-site-verification=abc123def456"
-_dmarc   IN TXT     "v=DMARC1; p=quarantine"
+@                                    IN TXT     "v=spf1 include:_spf.protonmail.ch ~all"
+@                                    IN TXT     "google-site-verification=abc123def456"
+_dmarc                               IN TXT     "v=DMARC1; p=quarantine"
 ```
 
 Things to notice:
 
+- **Fixed columns**: owner (30 chars), TTL (5, blank when it matches `$TTL`, right-aligned otherwise), class, and type — so even zones with long `_domainkey` owners stay perfectly aligned.
 - **`$TTL` is derived from your records** — it is set to the most common record TTL, and only records that deviate carry an explicit TTL (the `300` and `1800` above). The export is TTL-lossless: re-parsing it yields exactly the TTLs the provider reported.
 - **ANAME records are preserved as ANAME.** ANAME is not a standard DNS record type (it exists only inside providers), and DME's own zone export *flattens* ANAMEs into resolved A-record snapshots — which go stale as soon as the target rotates. `dmez` keeps them first-class so the file remains a faithful, apply-able representation of your account. If you need an RFC-portable file (for BIND, or to migrate providers), pass `--strict-rfc` to the `dmez zone export` command: ANAMEs are flattened into their currently resolved A records, and a warning is printed for each conversion — if and only if a conversion happened.
 - **Apex NS records are omitted by default** since DME manages them; pass `--include-apex-ns` to include them.
@@ -244,14 +242,14 @@ The edited file from step 2 might look like:
 $ORIGIN mail.example.com.
 $TTL 300
 
-click    IN CNAME   links.mailer.example.net.
+click                                IN CNAME   links.mailer.example.net.
 
-@        IN MX      10 inbound-smtp.us-east-1.amazonaws.com.
-send     IN MX      10 feedback-smtp.us-east-1.amazonses.com.
+@                                    IN MX      10 inbound-smtp.us-east-1.amazonaws.com.
+send                                 IN MX      10 feedback-smtp.us-east-1.amazonses.com.
 
-_dmarc   IN TXT     "v=DMARC1; p=none;"
-mailer._domainkey IN TXT     "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7abc123...AQAB"
-send     IN TXT     "v=spf1 include:amazonses.com ~all"
+_dmarc                               IN TXT     "v=DMARC1; p=none;"
+mailer._domainkey                    IN TXT     "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC7abc123...AQAB"
+send                                 IN TXT     "v=spf1 include:amazonses.com ~all"
 ```
 
 > [!NOTE]
@@ -362,12 +360,12 @@ Once you have the key and the secret, you have several choices:
 
   ```ruby
   require 'dnsmadeeasy'
-  
+
   DnsMadeEasy.configure do |config|
     config.api_key = 'XXXX'
     config.api_secret = 'YYYY'
   end
-  
+
   DnsMadeEasy.domains.data.first.name #=> 'moo.gamespot.com'
   ```
 
@@ -447,7 +445,7 @@ In a nutshell you have three ways to access all methods provided by the [`DnsMad
 
 Whether or not you are accessing a single account or multiple, it is recommended that you save your credentials (the API key and the secret) encrypted in the above mentioned file `~/.dnsmadeeasy/credentials.yml` (or any file of you preference).
 
->  [!WARNING]
+> [!WARNING]
 >
 > _**DO NOT check that file into your repo! If you use encryption, do not check in your key!**_
 
@@ -516,8 +514,6 @@ All public methods of this library return a Hash-like object, that is actually a
 > [!NOTE]
 >
 > `to_hash` converts the entire object to a regular hash, including the deeply nested hashes, while `to_h` only converts the primary object, but not the nested hashes. Here is an example below -- in the first instance where we call `to_h` we are still able to call `.value` on the nested object, because only the top-level `Mash` has been converted into a `Hash`. In the second example, this call fails, because this method does not exist, and the value must be accessed via the square brackets:
-
-
 
 ```ruby
 IRB > recs.to_h['data'].last.value
@@ -783,8 +779,6 @@ DME.requests_remaining
 #=> 19898
 ```
 
-
-
 > [!NOTE]
 > Information is not available until an API call has been made.
 
@@ -806,7 +800,7 @@ It was mentioned above that the credentials YAML file may contain encrypted valu
 >
 > There is a much better encryption facility called `sopsy` written in Rust. We highly recommend you use `sopsy` for encrypting your secrets, as it mints private keys on a Mac inside Appple Enclave hardware chip. For more information please see [sopsy's website](https://sopsy-cli.dev) or the [Github Project](https://github.com/kigster/sopsy).
 
-------
+______________________________________________________________________
 
 In order to encrypt your values, you need to perform the following steps:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DnsMadeEasy (`dmez`)
+# ADnsMadeEasy (`dmez`)
 
 [![Gem Version](https://badge.fury.io/rb/dnsmadeeasy.svg?icon=si%3Arubygems)](https://badge.fury.io/rb/dnsmadeeasy)&nbsp;![coverage](docs/badges/coverage_badge.svg)&nbsp;![Gem Total Downloads](https://img.shields.io/gem/dt/dnsmadeeasy?style=for-the-badge&logoSize=auto)
 
@@ -73,11 +73,11 @@ This is the flagship feature of version 1.0: your DME zones become plain text fi
 ```bash
 $ dmez zone --help
 Commands:
-  dmez zone apply FILE      # Apply DNS changes for a zone file
-  dmez zone export DOMAIN   # Export DNS Made Easy records as a canonical zone file
-  dmez zone fmt FILE        # Format a DNS zone file
-  dmez zone plan FILE       # Plan DNS changes for a zone file
-  dmez zone validate FILE   # Validate a DNS zone file
+  dmez zone apply DOMAIN FILE   # Apply DNS changes for a zone file
+  dmez zone export DOMAIN       # Export DNS Made Easy records as a canonical zone file
+  dmez zone fmt FILE            # Format a DNS zone file
+  dmez zone plan DOMAIN FILE    # Plan DNS changes for a zone file
+  dmez zone validate FILE       # Validate a DNS zone file
 ```
 
 #### `dmez zone export`
@@ -150,7 +150,7 @@ dmez zone fmt provider-export.zone > example.com.zone
 The heart of the workflow: compares a zone file (desired state) against the live records (actual state) and prints what would change — without changing anything.
 
 ```bash
-$ dmez zone plan example.com.zone --domain=example.com
+$ dmez zone plan example.com example.com.zone
 No changes.
 ```
 
@@ -175,14 +175,16 @@ Manual Review
 - **Skipped Deletes** — records in the account but not in the file. Deletes never happen by default; see `apply --delete-only`.
 - **Manual Review** — multiple records share the same owner/type identity and cannot be paired one-to-one (for example five apex `A` records in the file versus four in the account). The plan refuses to guess.
 
-Options: `--domain=NAME` (defaults to the file's `$ORIGIN`), `--format=text|json`, `--diff-ttl`.
+Options: `--format=text|json`, `--diff-ttl`.
+
+The domain is always the first argument, and the zone file's `$ORIGIN` is cross-checked against it (trailing dot and case are ignored): if the file says `$ORIGIN other.example.` while you passed `example.com`, the command fails before a single API call is made. Diffing the wrong domain against the wrong file should be an error, not a surprise apply.
 
 #### TTL Handling
 
 `zone plan` and `zone apply` **ignore TTL-only differences by default**: a record whose only deviation from the remote is its TTL is considered unchanged, and value updates preserve the remote TTL. Pass `--diff-ttl` to treat TTLs as part of the record — TTL-only differences then become updates, and applied records take the TTL from the zone file:
 
 ```bash
-$ dmez zone plan example.com.zone --domain=example.com --diff-ttl
+$ dmez zone plan example.com example.com.zone --diff-ttl
 Update
   - click CNAME links.cdn.example.net. (ttl=120) -> click CNAME links.cdn.example.net. (ttl=300)
 ```
@@ -192,7 +194,7 @@ Update
 Executes the plan against DNS Made Easy. You will be shown the number of actions and asked to confirm (skip the prompt with `--yes`):
 
 ```bash
-$ dmez zone apply example.com.zone --domain=example.com
+$ dmez zone apply example.com example.com.zone
 Apply 3 action(s)? Type yes to continue:
 yes
 ╔ ✔ OK ══════════════════════════════════════╗
@@ -226,13 +228,13 @@ $EDITOR mail.example.com.zone
 
 # 3. Validate and review the plan
 dmez zone validate mail.example.com.zone
-dmez zone plan mail.example.com.zone --domain=mail.example.com
+dmez zone plan mail.example.com mail.example.com.zone
 
 # 4. Apply (add-only is the safest mode for additive changes)
-dmez zone apply mail.example.com.zone --domain=mail.example.com --add-only --yes
+dmez zone apply mail.example.com mail.example.com.zone --add-only --yes
 
 # 5. Verify: re-running plan should now be a no-op
-dmez zone plan mail.example.com.zone --domain=mail.example.com
+dmez zone plan mail.example.com mail.example.com.zone
 # => No changes.
 ```
 

--- a/docs/plans/11-plan-zone-cli-arguments.md
+++ b/docs/plans/11-plan-zone-cli-arguments.md
@@ -1,0 +1,114 @@
+# 11 Plan: Consistent Zone CLI Arguments (and the Trailing-Dot 404)
+
+## Stacked PR Metadata
+
+- Plan identifier: `11`
+- Branch: `11-zone-cli-arguments`
+- Base branch: `master`
+- PR title: `11: Make domain a positional argument across zone commands`
+- PR description must reference: `Plan 11 - Consistent Zone CLI Arguments`
+
+## The Bug That Started This
+
+Found live, while writing the kig.re blog post announcing 1.0.1:
+
+```bash
+$ dmez zone export kig.re --output=kig.re.zone   # works
+$ dmez zone plan kig.re.zone                     # 404 "Not Found"
+$ dmez zone plan kig.re.zone --domain=kig.re     # works
+```
+
+`Plan#call` and `Apply#build_plan_context` fall back to the parsed zone's
+origin when `--domain` is absent:
+
+```ruby
+plan_domain = domain || desired_result.value!.origin
+```
+
+The parser returns the origin exactly as written in the file: `kig.re.`,
+with the RFC-mandated trailing dot. That FQDN goes straight into
+`records_for("kig.re.")`, the API has no such domain, 404.
+
+## The Design Decision
+
+The deeper problem is inconsistency, not the dot. Today:
+
+- `dmez zone export DOMAIN` — domain is a positional argument
+- `dmez zone plan FILE --domain=NAME` — domain is an option
+- `dmez zone apply FILE --domain=NAME` — domain is an option
+
+Decision (Konstantin): **domain is consistently an argument, never an
+option.** Zone files are provided by flags unless one is required for the
+command; a required file becomes a required argument following the domain.
+
+Applied to the command tree:
+
+| Command | New shape | Change |
+| ------- | --------- | ------ |
+| `zone export` | `dmez zone export DOMAIN [--output=FILE]` | none (already correct; output is optional, stays a flag, defaults to stdout) |
+| `zone plan` | `dmez zone plan DOMAIN FILE` | file was the only argument; domain was a flag |
+| `zone apply` | `dmez zone apply DOMAIN FILE [modes]` | same |
+| `zone validate` | `dmez zone validate FILE` | none (no provider involved, no domain to speak of) |
+| `zone fmt` | `dmez zone fmt FILE` | none |
+
+With `domain` required, origin inference is deleted rather than fixed. The
+bug becomes structurally impossible: there is nothing left to infer.
+
+## $ORIGIN Becomes a Cross-Check
+
+Deleting the inference does not mean ignoring `$ORIGIN`. Plan and apply now
+verify that the zone file agrees with the domain argument, before any API
+call is made:
+
+- Normalize both sides: strip one trailing dot, compare case-insensitively.
+  (`kig.re` == `kig.re.` == `KIG.RE.`)
+- If the file has an `$ORIGIN` and it disagrees with the domain argument,
+  fail fast with both values shown. Diffing `foo.com` against
+  `bar.com.zone` should be an error, not a surprise apply.
+- A zone file without `$ORIGIN` skips the check.
+
+This converts yesterday's bug into a safety feature.
+
+## Swapped-Argument Detection
+
+`dmez zone plan valid.zone example.com` is the muscle-memory mistake the
+new argument order invites. Two cheap guards:
+
+- When the zone file path does not exist, say so plainly
+  (`Zone file not found: example.com`) instead of an unhandled `Errno::ENOENT`.
+- When, additionally, the *domain* argument names an existing file, append:
+  `It looks like the arguments are swapped. Usage: dmez zone plan DOMAIN FILE`.
+
+## Out of Scope
+
+- `dme account` argument shapes.
+- `validate`/`fmt` error-handling polish beyond what exists.
+- Version bump: this is a breaking CLI change one day after 1.0.1 shipped
+  (16 downloads). Recommend releasing as **1.1.0** with the README calling
+  out the new shapes; the maintainer bumps the version at release time.
+
+## RSpec Requirements
+
+Update `spec/lib/dns_made_easy/cli/zone_aruba_spec.rb`:
+
+- Rewrite every `zone plan` / `zone apply` invocation to
+  `dme zone plan example.com valid.zone ...` (domain first, file second).
+- Add: plan with origin `example.com.` (trailing dot in file) and domain
+  argument `example.com` succeeds — the normalization test.
+- Add: plan with a mismatched origin fails, names both values, makes no
+  API call.
+- Add: plan with swapped arguments fails with the swap hint.
+- Add: plan with a missing zone file fails with `Zone file not found`.
+- Keep specs in the modern style: nested `describe`/`context`, block-local
+  `subject`, concise `it { ... }`, `its(:property) { ... }` where it reads
+  better.
+
+## Acceptance Criteria
+
+- `dmez zone plan kig.re kig.re.zone` round-trips against production with
+  `No changes.` (verified live, read-only).
+- The 1.0.1 failure mode (`zone plan FILE` → 404) can no longer be
+  expressed: the CLI rejects the invocation with a usage error.
+- Mismatched `$ORIGIN` vs domain argument fails before any API request.
+- README zone examples reflect the new shapes.
+- Full spec suite passes; rubocop clean.

--- a/lib/dnsmadeeasy/cli/commands/zone.rb
+++ b/lib/dnsmadeeasy/cli/commands/zone.rb
@@ -43,8 +43,8 @@ module DnsMadeEasy
 
             lines = [
               'Domain and zone file disagree.',
-              "Domain argument: #{domain}",
-              "Zone file $ORIGIN: #{origin}"
+              kv('Domain argument', domain),
+              kv('Zone file $ORIGIN', origin)
             ]
             lines << swap_hint if ::File.file?(domain.to_s)
             error(lines.join("\n"))
@@ -71,7 +71,7 @@ module DnsMadeEasy
 
             if result.success?
               record_count = result.value!.records.length
-              success("Zone file is valid.\nRecords: #{record_count}")
+              success("Zone file is valid.\n#{kv('Records', record_count)}")
             else
               warning("Zone file is invalid.\n#{result.failure.join("\n")}")
               raise ReportedError, 'zone file is invalid'
@@ -90,7 +90,7 @@ module DnsMadeEasy
 
             if result.success?
               puts DnsMadeEasy::Zone::Serializer.new(result.value!)
-              success("Zone file formatted.\nRecords: #{result.value!.records.length}")
+              success("Zone file formatted.\n#{kv('Records', result.value!.records.length)}")
             else
               error("Zone file is invalid.\n#{result.failure.join("\n")}")
               raise ReportedError, 'zone file is invalid'
@@ -139,8 +139,12 @@ module DnsMadeEasy
               include_apex_ns: options[:include_apex_ns]
             )
             success(
-              "Zone export complete.\nDomain: #{domain}\nRecords: #{records.length}\n" \
-              "Destination: #{options[:output] || 'STDOUT'}"
+              [
+                'Zone export complete.',
+                kv('Domain', domain),
+                kv('Records', records.length),
+                kv('Destination', options[:output] || 'STDOUT')
+              ].join("\n")
             )
           end
 
@@ -258,9 +262,11 @@ module DnsMadeEasy
           def plan_summary(domain, plan)
             [
               "Zone plan complete for #{domain}.",
-              "Creates: #{plan.creates.length}, Updates: #{plan.updates.length}",
-              "Skipped creates: #{plan.skipped_creates.length}, Skipped deletes: #{plan.skipped_deletes.length}",
-              "Manual review: #{plan.ambiguous.length}"
+              kv('Creates', plan.creates.length),
+              kv('Updates', plan.updates.length),
+              kv('Skipped creates', plan.skipped_creates.length),
+              kv('Skipped deletes', plan.skipped_deletes.length),
+              kv('Manual review', plan.ambiguous.length)
             ].join("\n")
           end
 
@@ -357,10 +363,12 @@ module DnsMadeEasy
           end
 
           def print_apply_summary(domain, result)
-            summary = "Zone apply complete for #{domain}.\n" \
-                      "Applied: #{result.applied_actions.length}\n" \
-                      "Failed: #{result.failed_actions.length}\n" \
-                      "Skipped: #{result.skipped_actions.length}"
+            summary = [
+              "Zone apply complete for #{domain}.",
+              kv('Applied', result.applied_actions.length),
+              kv('Failed', result.failed_actions.length),
+              kv('Skipped', result.skipped_actions.length)
+            ].join("\n")
 
             result.failed_actions.empty? ? success(summary) : warning(summary)
           end

--- a/lib/dnsmadeeasy/cli/commands/zone.rb
+++ b/lib/dnsmadeeasy/cli/commands/zone.rb
@@ -19,6 +19,47 @@ module DnsMadeEasy
     module Commands
       # Zone-file management commands.
       module Zone
+        # Shared handling for the `DOMAIN FILE` positional-argument pair used
+        # by the provider-facing commands (plan, apply). Reads the zone file
+        # with a friendly failure instead of a raw Errno::ENOENT, and verifies
+        # the file's $ORIGIN agrees with the domain argument BEFORE any API
+        # call is made — diffing foo.com against bar.com.zone should be an
+        # error, not a surprise apply. Comparison strips the RFC trailing dot
+        # ($ORIGIN is an FQDN like "kig.re.") and ignores case.
+        module DomainArguments
+          private
+
+          def read_zone_source!(file, domain:)
+            ::File.read(file)
+          rescue Errno::ENOENT, Errno::EISDIR
+            lines = ["Zone file not found: #{file}"]
+            lines << swap_hint if ::File.file?(domain.to_s)
+            error(lines.join("\n"))
+            raise ReportedError, 'zone file not found'
+          end
+
+          def ensure_origin_matches!(domain:, origin:)
+            return if origin.nil? || normalize_domain(origin) == normalize_domain(domain)
+
+            lines = [
+              'Domain and zone file disagree.',
+              "Domain argument: #{domain}",
+              "Zone file $ORIGIN: #{origin}"
+            ]
+            lines << swap_hint if ::File.file?(domain.to_s)
+            error(lines.join("\n"))
+            raise ReportedError, 'domain and zone file disagree'
+          end
+
+          def normalize_domain(name)
+            name.to_s.delete_suffix('.').downcase
+          end
+
+          def swap_hint
+            "It looks like the arguments are swapped. Usage: #{usage_hint}"
+          end
+        end
+
         # Validates a standard DNS zone file.
         class Validate < Base
           desc 'Validate a DNS zone file'
@@ -175,21 +216,25 @@ module DnsMadeEasy
 
         # Produces a non-destructive plan comparing a zone file to remote records.
         class Plan < Base
+          include DomainArguments
+
           desc 'Plan DNS changes for a zone file'
 
+          argument :domain, required: true, desc: 'Domain name'
           argument :file, required: true, desc: 'Zone file path'
 
-          option :domain, required: false, desc: 'Domain name'
           option :format, values: %w[text json], default: 'text', required: false, desc: 'Plan output format'
           option :diff_ttl, type: :boolean, default: false, desc: 'Treat TTL-only differences as updates'
 
-          def call(file:, domain: nil, format: 'text', diff_ttl: false, credentials: nil, api_key: nil, api_secret: nil, **)
+          def call(domain:, file:, format: 'text', diff_ttl: false, credentials: nil, api_key: nil, api_secret: nil, **)
             configure_authentication(credentials: credentials, api_key: api_key, api_secret: api_secret)
 
-            desired_result = DnsMadeEasy::Zone::Parser.new(::File.read(file)).call
+            desired_result = DnsMadeEasy::Zone::Parser.new(read_zone_source!(file, domain: domain)).call
             return fail_with('Zone file is invalid', desired_result.failure) if desired_result.failure?
 
-            plan_domain = domain || desired_result.value!.origin
+            ensure_origin_matches!(domain: domain, origin: desired_result.value!.origin)
+
+            plan_domain = normalize_domain(domain)
             remote_result = remote_records(plan_domain)
             return fail_with('Remote records are invalid', remote_result.failure) if remote_result.failure?
 
@@ -205,6 +250,10 @@ module DnsMadeEasy
           end
 
           private
+
+          def usage_hint
+            'dmez zone plan DOMAIN FILE'
+          end
 
           def plan_summary(domain, plan)
             [
@@ -227,11 +276,13 @@ module DnsMadeEasy
 
         # Applies a reviewed zone plan safely.
         class Apply < Base
+          include DomainArguments
+
           desc 'Apply DNS changes for a zone file'
 
+          argument :domain, required: true, desc: 'Domain name'
           argument :file, required: true, desc: 'Zone file path'
 
-          option :domain, required: false, desc: 'Domain name'
           option :yes, aliases: ['y'], type: :boolean, default: false, desc: 'Apply without confirmation prompt'
           option :add_only, aliases: ['a'], type: :boolean, default: false, desc: 'Only add missing records'
           option :delete_only, aliases: ['d'], type: :boolean, default: false, desc: 'Only apply deletions'
@@ -242,7 +293,8 @@ module DnsMadeEasy
             configure_authentication(credentials: options[:credentials], api_key: options[:api_key],
                                      api_secret: options[:api_secret])
 
-            plan_context = build_plan_context(options.fetch(:file), options[:domain], compare_ttl: options[:diff_ttl])
+            plan_context = build_plan_context(options.fetch(:domain), options.fetch(:file),
+                                              compare_ttl: options[:diff_ttl])
             return fail_with('Zone apply failed', plan_context.failure) if plan_context.failure?
 
             mode = apply_mode(options)
@@ -265,11 +317,13 @@ module DnsMadeEasy
 
           private
 
-          def build_plan_context(file, domain, compare_ttl: false)
-            desired_result = DnsMadeEasy::Zone::Parser.new(::File.read(file)).call
+          def build_plan_context(domain, file, compare_ttl: false)
+            desired_result = DnsMadeEasy::Zone::Parser.new(read_zone_source!(file, domain: domain)).call
             return desired_result if desired_result.failure?
 
-            plan_domain = domain || desired_result.value!.origin
+            ensure_origin_matches!(domain: domain, origin: desired_result.value!.origin)
+
+            plan_domain = normalize_domain(domain)
             remote_result = DnsMadeEasy::Zone::RemoteAdapter.new(DnsMadeEasy.client.records_for(plan_domain),
                                                                  domain: plan_domain).call
             return remote_result if remote_result.failure?
@@ -281,6 +335,10 @@ module DnsMadeEasy
             ).call
 
             Dry::Monads::Success(domain: plan_domain, plan: plan, remote_records: remote_result.value!)
+          end
+
+          def usage_hint
+            'dmez zone apply DOMAIN FILE'
           end
 
           def apply_mode(options)

--- a/lib/dnsmadeeasy/cli/message_helpers.rb
+++ b/lib/dnsmadeeasy/cli/message_helpers.rb
@@ -43,6 +43,7 @@ module DnsMadeEasy
 
         def print_box(box_type, message, output)
           box = TTY::Box.public_send(box_type, message, **BOX_OPTIONS)
+          output.puts
           output.puts(box)
           box
         end

--- a/lib/dnsmadeeasy/cli/message_helpers.rb
+++ b/lib/dnsmadeeasy/cli/message_helpers.rb
@@ -18,6 +18,9 @@ module DnsMadeEasy
         width: 85
       }.freeze
 
+      # Right-aligned key column for "key: value" lines inside boxes.
+      KEY_WIDTH = 30
+
       class << self
         attr_accessor :stdout, :stderr
 
@@ -47,6 +50,10 @@ module DnsMadeEasy
           output.puts(box)
           box
         end
+
+        def kv(key, value)
+          format("%#{KEY_WIDTH}s: %s", key, value)
+        end
       end
 
       # Boxed helpers for command classes. The warn box is exposed as
@@ -66,6 +73,10 @@ module DnsMadeEasy
 
         def success(message)
           MessageHelpers.print_box(:success, message, message_output)
+        end
+
+        def kv(key, value)
+          MessageHelpers.kv(key, value)
         end
 
         private

--- a/lib/dnsmadeeasy/version.rb
+++ b/lib/dnsmadeeasy/version.rb
@@ -2,5 +2,5 @@
 
 module DnsMadeEasy
   # Version 1.0+ is supporting zone file manipulation
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/lib/dnsmadeeasy/zone/serializer.rb
+++ b/lib/dnsmadeeasy/zone/serializer.rb
@@ -6,6 +6,10 @@ module DnsMadeEasy
   module Zone
     # Emits deterministic, normalized zone-file text.
     class Serializer
+      # Fixed columns: owner (30), TTL (5, blank when it matches $TTL),
+      # "IN " (3), record type (7), then the payload.
+      RECORD_FORMAT = '%-30s %5s %-3s%-7s %s'
+
       def initialize(zone_file, omit_apex_ns: true)
         @zone_file = zone_file
         @omit_apex_ns = omit_apex_ns
@@ -83,13 +87,13 @@ module DnsMadeEasy
       end
 
       def serialize_record(record)
-        [record.owner.ljust(8), ttl_token(record), 'IN', record.type.ljust(7), record_payload(record)].compact.join(' ')
+        format(RECORD_FORMAT, record.owner, ttl_token(record), 'IN', record.type, record_payload(record))
       end
 
       # A single $TTL cannot represent a real zone, so records that deviate
-      # from the zone default carry an explicit TTL.
+      # from the zone default carry an explicit right-aligned TTL.
       def ttl_token(record)
-        record.ttl == zone_file.ttl ? nil : record.ttl.to_s
+        record.ttl == zone_file.ttl ? '' : record.ttl.to_s
       end
 
       def record_payload(record)

--- a/spec/fixtures/zones/formatted.zone
+++ b/spec/fixtures/zones/formatted.zone
@@ -1,9 +1,9 @@
 $ORIGIN example.com.
 $TTL 300
 
-@        IN A       203.0.113.10
-www      IN CNAME   @
+@                                    IN A       203.0.113.10
+www                                  IN CNAME   @
 
-@        IN MX      10 mail.example.com.
+@                                    IN MX      10 mail.example.com.
 
-@        IN TXT     "v=spf1 include:_spf.google.com ~all"
+@                                    IN TXT     "v=spf1 include:_spf.google.com ~all"

--- a/spec/lib/dns_made_easy/cli/message_helpers_spec.rb
+++ b/spec/lib/dns_made_easy/cli/message_helpers_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe DnsMadeEasy::CLI::MessageHelpers do
     it_behaves_like 'a boxed stderr helper', :success, :success, 'success-box'
   end
 
+  describe '.kv' do
+    it 'right-aligns the key to 30 characters' do
+      expect(described_class.kv('Records', 4)).to eq('                       Records: 4')
+    end
+  end
+
   describe 'when included into a command' do
     subject(:command) { command_class.new }
 

--- a/spec/lib/dns_made_easy/cli/message_helpers_spec.rb
+++ b/spec/lib/dns_made_easy/cli/message_helpers_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe DnsMadeEasy::CLI::MessageHelpers do
       message_helper
     end
 
-    it 'prints the boxed message to stderr, keeping stdout clean' do
+    it 'prints the boxed message to stderr after a blank line, keeping stdout clean' do
       message_helper
 
-      expect(stderr.string).to eq("#{expected_box}\n")
+      expect(stderr.string).to eq("\n#{expected_box}\n")
       expect(stdout.string).to be_empty
     end
   end

--- a/spec/lib/dns_made_easy/cli/zone_aruba_spec.rb
+++ b/spec/lib/dns_made_easy/cli/zone_aruba_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe 'dme zone', type: :aruba do
     end
 
     it { is_expected.to include('$ORIGIN example.com.') }
-    it { is_expected.to include('@        IN A       203.0.113.10') }
-    it { is_expected.to include('delegated IN NS      ns1.example.net.') }
+    it { is_expected.to include('@                                    IN A       203.0.113.10') }
+    it { is_expected.to include('delegated                            IN NS      ns1.example.net.') }
     it { is_expected.not_to include('HTTPRED') }
     it { is_expected.not_to include('ns1.dnsmadeeasy.com') }
   end
@@ -108,7 +108,7 @@ RSpec.describe 'dme zone', type: :aruba do
       run_command_and_stop('dme zone export example.com --include-apex-ns --api-key=cli-key --api-secret=cli-secret')
     end
 
-    it { is_expected.to include('@        IN NS      ns1.dnsmadeeasy.com.') }
+    it { is_expected.to include('@                                    IN NS      ns1.dnsmadeeasy.com.') }
   end
 
   describe 'export to output file' do
@@ -119,7 +119,7 @@ RSpec.describe 'dme zone', type: :aruba do
     end
 
     it { is_expected.to include('$ORIGIN example.com.') }
-    it { is_expected.to include('@        IN A       203.0.113.10') }
+    it { is_expected.to include('@                                    IN A       203.0.113.10') }
   end
 
   describe 'export as json' do
@@ -158,7 +158,7 @@ RSpec.describe 'dme zone', type: :aruba do
         run_command_and_stop('dme zone export example.com --api-key=cli-key --api-secret=cli-secret')
       end
 
-      it { is_expected.to include('@        IN ANAME   cdn.example.net.') }
+      it { is_expected.to include('@                                    IN ANAME   cdn.example.net.') }
 
       describe 'stderr' do
         subject(:error_output) { last_command_started.stderr }
@@ -176,7 +176,7 @@ RSpec.describe 'dme zone', type: :aruba do
       end
 
       it { is_expected.not_to include('ANAME') }
-      it { is_expected.to include('@        IN A       203.0.113.80') }
+      it { is_expected.to include('@                                    IN A       203.0.113.80') }
 
       describe 'stderr' do
         subject(:error_output) { last_command_started.stderr }

--- a/spec/lib/dns_made_easy/cli/zone_aruba_spec.rb
+++ b/spec/lib/dns_made_easy/cli/zone_aruba_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe 'dme zone', type: :aruba do
     subject(:output) { last_command_started.stdout }
 
     before do
-      run_command_and_stop('dme zone plan valid.zone --domain=example.com --api-key=cli-key --api-secret=cli-secret')
+      run_command_and_stop('dme zone plan example.com valid.zone --api-key=cli-key --api-secret=cli-secret')
     end
 
     it { is_expected.to include('Create') }
@@ -223,7 +223,7 @@ RSpec.describe 'dme zone', type: :aruba do
         @        IN MX      10 mail.example.com.
         @        IN TXT     "v=spf1 include:_spf.google.com ~all"
       ZONE
-      run_command_and_stop('dme zone plan apex-ns.zone --domain=example.com --api-key=cli-key --api-secret=cli-secret')
+      run_command_and_stop('dme zone plan example.com apex-ns.zone --api-key=cli-key --api-secret=cli-secret')
     end
 
     it { is_expected.to include('Skipped Creates') }
@@ -240,7 +240,7 @@ RSpec.describe 'dme zone', type: :aruba do
 
     context 'when TTLs are ignored by default' do
       before do
-        run_command_and_stop('dme zone plan valid.zone --domain=example.com --api-key=cli-key --api-secret=cli-secret')
+        run_command_and_stop('dme zone plan example.com valid.zone --api-key=cli-key --api-secret=cli-secret')
       end
 
       it { is_expected.not_to include('Update') }
@@ -249,7 +249,7 @@ RSpec.describe 'dme zone', type: :aruba do
     context 'with --diff-ttl' do
       before do
         run_command_and_stop(
-          'dme zone plan valid.zone --domain=example.com --diff-ttl --api-key=cli-key --api-secret=cli-secret'
+          'dme zone plan example.com valid.zone --diff-ttl --api-key=cli-key --api-secret=cli-secret'
         )
       end
 
@@ -262,7 +262,7 @@ RSpec.describe 'dme zone', type: :aruba do
 
     before do
       run_command_and_stop(
-        'dme zone plan valid.zone --domain=example.com --format=json --api-key=cli-key --api-secret=cli-secret'
+        'dme zone plan example.com valid.zone --format=json --api-key=cli-key --api-secret=cli-secret'
       )
     end
 
@@ -275,7 +275,7 @@ RSpec.describe 'dme zone', type: :aruba do
       expect(client).to receive(:create_record).with('example.com', 'www', 'CNAME', '@', hash_including('ttl' => 300))
 
       run_command_and_stop(
-        'dme zone apply valid.zone --domain=example.com --add-only --yes --api-key=cli-key --api-secret=cli-secret'
+        'dme zone apply example.com valid.zone --add-only --yes --api-key=cli-key --api-secret=cli-secret'
       )
 
       last_command_started.stderr
@@ -292,7 +292,7 @@ RSpec.describe 'dme zone', type: :aruba do
       expect(client).not_to receive(:delete_record).with('example.com', 4)
 
       run_command_and_stop(
-        'dme zone apply valid.zone --domain=example.com --delete-only --yes --api-key=cli-key --api-secret=cli-secret'
+        'dme zone apply example.com valid.zone --delete-only --yes --api-key=cli-key --api-secret=cli-secret'
       )
 
       last_command_started.stderr
@@ -307,12 +307,81 @@ RSpec.describe 'dme zone', type: :aruba do
     subject(:error_output) do
       expect(client).not_to receive(:create_record)
 
-      run_command_and_stop('dme zone apply valid.zone --domain=example.com --api-key=cli-key --api-secret=cli-secret')
+      run_command_and_stop('dme zone apply example.com valid.zone --api-key=cli-key --api-secret=cli-secret')
 
       last_command_started.stderr
     end
 
     it { is_expected.to include('Apply 1 action(s)? Type yes to continue:') }
     it { is_expected.to include('zone apply cancelled') }
+  end
+
+  describe 'plan normalizes the domain argument for the API' do
+    subject(:error_output) do
+      # The 1.0.1 bug shipped "kig.re." (trailing-dot FQDN) to the API and got
+      # a 404; the argument must reach the client dot-free and downcased. Any
+      # other argument raises, which fails the command and thus the example.
+      allow(client).to receive(:records_for).and_raise('records_for called with a non-normalized domain')
+      allow(client).to receive(:records_for).with('example.com').and_return('data' => remote_records_data)
+
+      run_command_and_stop('dme zone plan EXAMPLE.COM. valid.zone --api-key=cli-key --api-secret=cli-secret')
+
+      last_command_started.stderr
+    end
+
+    it { is_expected.to include('Zone plan complete for example.com') }
+  end
+
+  describe 'plan with a mismatched $ORIGIN' do
+    subject(:error_output) do
+      expect(client).not_to receive(:records_for)
+
+      run_command_and_stop('dme zone plan other.example valid.zone --api-key=cli-key --api-secret=cli-secret')
+
+      last_command_started.stderr
+    end
+
+    it { is_expected.to include('Domain and zone file disagree.') }
+    it { is_expected.to include('Domain argument: other.example') }
+    it { is_expected.to include('Zone file $ORIGIN: example.com.') }
+    it { is_expected.not_to include('arguments are swapped') }
+  end
+
+  describe 'plan with swapped arguments' do
+    subject(:error_output) do
+      expect(client).not_to receive(:records_for)
+
+      run_command_and_stop('dme zone plan valid.zone example.com --api-key=cli-key --api-secret=cli-secret')
+
+      last_command_started.stderr
+    end
+
+    it { is_expected.to include('Zone file not found: example.com') }
+    it { is_expected.to include('It looks like the arguments are swapped. Usage: dmez zone plan DOMAIN FILE') }
+  end
+
+  describe 'plan with a missing zone file' do
+    subject(:error_output) do
+      run_command_and_stop('dme zone plan example.com missing.zone --api-key=cli-key --api-secret=cli-secret')
+
+      last_command_started.stderr
+    end
+
+    it { is_expected.to include('Zone file not found: missing.zone') }
+    it { is_expected.not_to include('arguments are swapped') }
+  end
+
+  describe 'apply with a mismatched $ORIGIN' do
+    subject(:error_output) do
+      expect(client).not_to receive(:records_for)
+      expect(client).not_to receive(:create_record)
+
+      run_command_and_stop('dme zone apply other.example valid.zone --yes --api-key=cli-key --api-secret=cli-secret')
+
+      last_command_started.stderr
+    end
+
+    it { is_expected.to include('Domain and zone file disagree.') }
+    it { is_expected.to include('Zone file $ORIGIN: example.com.') }
   end
 end

--- a/spec/lib/dns_made_easy/zone/serializer_spec.rb
+++ b/spec/lib/dns_made_easy/zone/serializer_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe DnsMadeEasy::Zone::Serializer do
         ]
       end
 
-      it { is_expected.not_to include('@        IN NS') }
-      it { is_expected.to include('delegated IN NS      ns1.example.net.') }
+      it { is_expected.not_to include('@                                    IN NS') }
+      it { is_expected.to include('delegated                            IN NS      ns1.example.net.') }
     end
 
     context 'with records whose TTL differs from the zone TTL' do
@@ -41,8 +41,8 @@ RSpec.describe DnsMadeEasy::Zone::Serializer do
         ]
       end
 
-      it { is_expected.to include('click    120 IN CNAME   links1.resend-dns.com.') }
-      it { is_expected.to include('@        IN A       203.0.113.10') }
+      it { is_expected.to include('click                            120 IN CNAME   links1.resend-dns.com.') }
+      it { is_expected.to include('@                                    IN A       203.0.113.10') }
     end
   end
 
@@ -74,7 +74,7 @@ RSpec.describe DnsMadeEasy::Zone::Serializer do
     let(:first_pass) { described_class.new(zone_file).to_s }
 
     it { is_expected.to eq(first_pass) }
-    it { is_expected.to include('click    120 IN CNAME   links1.resend-dns.com.') }
-    it { is_expected.to include('send     120 IN TXT     "v=spf1 include:amazonses.com ~all"') }
+    it { is_expected.to include('click                            120 IN CNAME   links1.resend-dns.com.') }
+    it { is_expected.to include('send                             120 IN TXT     "v=spf1 include:amazonses.com ~all"') }
   end
 end

--- a/spec/lib/dnsmadeeasy_spec.rb
+++ b/spec/lib/dnsmadeeasy_spec.rb
@@ -21,7 +21,7 @@ module DnsMadeEasy
     describe 'version' do
       subject(:version) { described_class::VERSION }
 
-      it { is_expected.to eq('1.0.1') }
+      it { is_expected.to eq('1.0.2') }
     end
 
     describe 'configured API credentials' do


### PR DESCRIPTION
# Require DOMAIN FILE arguments for zone plan/apply (v1.0.2)

## Summary

`dmez zone plan` and `dmez zone apply` now take a required `DOMAIN FILE` positional pair instead of an optional `--domain` flag, and refuse to run when the zone file's `$ORIGIN` disagrees with the domain argument. This closes the operator-error window where a zone file could be planned or applied against the wrong domain.

## Description

- Both commands share a new `DomainArguments` module: the zone file is read with a friendly boxed error instead of a raw `Errno::ENOENT`, and the file's `$ORIGIN` must agree with the domain argument (trailing-dot and case insensitive) before any API call is made.
- When the arguments appear swapped (the domain argument is an existing file on disk), the error includes a usage hint showing the correct order.
- The argument order mirrors `dmez zone export DOMAIN`, so the whole workflow reads consistently: `export DOMAIN`, `plan DOMAIN FILE`, `apply DOMAIN FILE`.
- Version bumped to 1.0.2; the implementation plan is recorded in `docs/plans/11-plan-zone-cli-arguments.md`.

## Testing

332 examples, 0 failures; RuboCop clean. New aruba coverage exercises the origin-mismatch error, the swapped-arguments hint, and the missing-file error path end to end.

## Backwards Compatibility

Breaking for `plan`/`apply` invocations that relied on `--domain` or on inferring the domain from `$ORIGIN`: the domain is now the first positional argument. This is a deliberate CLI tightening within the 1.0 series while adoption is fresh.
